### PR TITLE
Improve Windows Build and Runtime Compatibility

### DIFF
--- a/src/bin/bundle_windows.rs
+++ b/src/bin/bundle_windows.rs
@@ -8,12 +8,34 @@ fn main() {
         eprintln!("❌ Warning: You are running Windows bundler on Linux. This may fail if cross-compilation tools (like cargo-bundle or WiX) aren't set up.");
     }
 
-    let status = Command::new("sh")
-        .arg("scripts/bundle_windows.sh")
-        .status()
-        .expect("Failed to execute bundle script");
+    // 1. Build the app
+    println!("🏗️  Building release binary...");
+    let mut cargo_build = Command::new("cargo");
+    cargo_build.arg("build").arg("--release");
+
+    let status = cargo_build.status().expect("Failed to execute cargo build");
 
     if !status.success() {
         std::process::exit(status.code().unwrap_or(1));
     }
+
+    // 2. Bundle using cargo-bundle
+    println!("📦 Creating MSI installer...");
+    let mut cargo_bundle = Command::new("cargo");
+    cargo_bundle.arg("bundle").arg("--release").arg("--format").arg("msi");
+
+    let status = cargo_bundle.status();
+
+    match status {
+        Ok(s) if s.success() => {
+            println!("✅ MSI Bundle created successfully.");
+            println!("📂 Package location: target/release/bundle/msi");
+        }
+        _ => {
+            println!("⚠️  MSI bundling failed. This usually requires WiX Toolset on the host system.");
+            println!("   Standalone executable is available at: target/release/yt-frontend.exe");
+        }
+    }
+
+    println!("🚀 Windows distribution process complete.");
 }


### PR DESCRIPTION
This PR addresses several platform-specific issues that hindered the Windows build and runtime stability of the Onyx Downloader. 

Key changes:
1. **Bundler Refactor**: `src/bin/bundle_windows.rs` now executes `cargo build` and `cargo bundle` directly using the Rust `Command` API. This ensures it works on Windows without requiring a POSIX-compliant shell like Git Bash or WSL.
2. **Binary Extensions**: Fixed an issue where the `bgutil-pot` binary was being looked for without the `.exe` extension on Windows, which would lead to runtime failures when starting the PO Token server.
3. **Cross-Platform Port Checking**: Replaced the use of the `lsof` command (Unix-specific) with a native Rust check using `tokio::net::TcpStream::connect` to see if port 8190 is already in use.
4. **Shell Command Safety**: Updated the FFmpeg cropping command for Windows to use `&&` instead of `&` for command chaining, ensuring the file move only occurs if the crop operation succeeds.

These changes significantly improve the reliability of the application on Windows systems while maintaining full compatibility with Linux and macOS.

Fixes #3

---
*PR created automatically by Jules for task [11128724951662426514](https://jules.google.com/task/11128724951662426514) started by @ryanharper*