### PR TITLE
Fix missing action error in GitHub CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,9 @@ jobs:
         run: cargo test
 
       - name: Install tarpaulin
-        uses: taiki-e/install-action@cargo-tarpaulin
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-tarpaulin
 
       - name: Run Test Coverage
         run: cargo tarpaulin --ignore-tests --out xml
@@ -48,9 +50,7 @@ jobs:
         run: cargo clippy -- -D warnings
 
       - name: Security Audit
-        uses: rustsec/audit-check@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions-rust-lang/audit@v1
 
   bom:
     name: Generate BOM


### PR DESCRIPTION
The CI workflow was failing with a "missing action" error because `taiki-e/install-action` was incorrectly invoked using `@cargo-tarpaulin` as a version ref. This has been corrected to use `@v2` with the tool specified in the `with` block. Additionally, the security audit step was modernized to use `actions-rust-lang/audit`, as the previously used `rustsec/audit-check` is deprecated and prone to permission issues. Verified that `cargo test` still passes in the local environment.

Fixes #15

---
*PR created automatically by Jules for task [4715208114522981972](https://jules.google.com/task/4715208114522981972) started by @ryanharper*